### PR TITLE
Allow to throttle by percentage or by seconds

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,7 +110,7 @@ Or at update:
 | template | `{prefix} {progress} {percent} ({done}/{total})` | The template of the whole line |
 | prefix | `Progress:` | The leading label |
 | animation | '{progress}' | The actual widget used for progress, can be `{bar}`, `{spinner}` or `{stream}`
-| throttle | 0 | Minimum value between two `update` call to issue a render
+| throttle | 0 | Minimum value between two `update` call to issue a render: can accept an `int` for an absolute throttling, a float for a percentage throttling (total must then be set) or a dimedelta for a throttling in seconds
 
 
 ## Built in template vars

--- a/examples.py
+++ b/examples.py
@@ -1,3 +1,4 @@
+from datetime import timedelta
 import sys
 import time
 
@@ -20,6 +21,7 @@ def call(bar):
 
 
 REGISTRY = []
+
 
 def register(func):
     REGISTRY.append(func)
@@ -95,6 +97,14 @@ def example_stream():
 def example_throttle():
 
     bar = ProgressBar(total=20, throttle=2, prefix='Throttling')
+    call(bar)
+
+
+@register
+def example_throttle_by_second():
+
+    bar = ProgressBar(total=20, throttle=timedelta(seconds=1),
+                      prefix='Throttling by second')
     call(bar)
 
 

--- a/progressist/__init__.py
+++ b/progressist/__init__.py
@@ -133,6 +133,9 @@ class ProgressBar:
                self._last_render + self.throttle.seconds > time.time()):
                 return True
             self._last_render = time.time()
+        else:
+            raise ValueError('Invalid type for throttle: '
+                             '{}'.format(type(self.throttle)))
 
     def render(self):
         if self.throttled:

--- a/progressist/__init__.py
+++ b/progressist/__init__.py
@@ -132,7 +132,8 @@ class ProgressBar:
                 throttle = max(1, self.total * self.throttle)
             throttle = self._last_render + throttle
             if self.done < throttle:
-                if not self.total or throttle <= self.total:
+                if (not self.total or throttle <= self.total
+                   or self.done < self.total):
                     return True
             self._last_render = self.done
         elif isinstance(self.throttle, datetime.timedelta):

--- a/progressist/__init__.py
+++ b/progressist/__init__.py
@@ -118,7 +118,7 @@ class ProgressBar:
     @property
     def throttled(self):
         if not self.throttle:
-            return
+            return False
         if isinstance(self.throttle, (int, float)):
             throttle = self.throttle
             if isinstance(self.throttle, float):
@@ -136,6 +136,7 @@ class ProgressBar:
         else:
             raise ValueError('Invalid type for throttle: '
                              '{}'.format(type(self.throttle)))
+        return False
 
     def render(self):
         if self.throttled:

--- a/progressist/__init__.py
+++ b/progressist/__init__.py
@@ -69,6 +69,13 @@ class ProgressBar:
             self.template = '\r' + self.template
         self.formatter = Formatter()
         self._last_render = 0
+        if self.throttle:
+            if not isinstance(self.throttle, (int, float, datetime.timedelta)):
+                raise ValueError('Invalid type for throttle: '
+                                 '{}'.format(type(self.throttle)))
+            if isinstance(self.throttle, float) and self.throttle > 1.0:
+                raise ValueError('Float throttle must be between 0 and 1.0. '
+                                 'Got {} instead.'.format(self.throttle))
 
     def format(self, tpl, *args, **kwargs):
         return self.formatter.vformat(tpl, None, self)
@@ -133,9 +140,6 @@ class ProgressBar:
                self._last_render + self.throttle.seconds > time.time()):
                 return True
             self._last_render = time.time()
-        else:
-            raise ValueError('Invalid type for throttle: '
-                             '{}'.format(type(self.throttle)))
         return False
 
     def render(self):

--- a/progressist/tests/test_progress.py
+++ b/progressist/tests/test_progress.py
@@ -3,6 +3,8 @@ import datetime
 
 import pytest
 
+from progressist import ProgressBar
+
 
 @pytest.mark.parametrize('input,expected', [
     (12, '0.0 KiB'),
@@ -276,9 +278,8 @@ def test_timedelta_throttle(bar, capsys, monkeypatch):
 
 
 def test_should_raise_if_throttle_type_is_invalid(bar):
-    bar.throttle = '1'
     with pytest.raises(ValueError):
-        bar.update(1)
+        ProgressBar(throttle='1')
 
 
 def test_eta(bar, capsys, monkeypatch):

--- a/progressist/tests/test_progress.py
+++ b/progressist/tests/test_progress.py
@@ -275,6 +275,12 @@ def test_timedelta_throttle(bar, capsys, monkeypatch):
     assert out == '\rBar: ===================================== 100/100\n'
 
 
+def test_should_raise_if_throttle_type_is_invalid(bar):
+    bar.throttle = '1'
+    with pytest.raises(ValueError):
+        bar.update(1)
+
+
 def test_eta(bar, capsys, monkeypatch):
 
     class fake_datetime(datetime.datetime):

--- a/progressist/tests/test_progress.py
+++ b/progressist/tests/test_progress.py
@@ -212,9 +212,14 @@ def test_throttle(bar, capsys):
     bar.update(done=42)
     out, err = capsys.readouterr()
     assert out == '\rBar: ===============                        42/100'
+    bar.update(done=98)
+    out, err = capsys.readouterr()
+    assert out == '\rBar: =====================================  98/100'
+    # Now throttle is higher than total, we should not print unless we reach
+    # the total.
     bar.update(done=99)
     out, err = capsys.readouterr()
-    assert out == '\rBar: =====================================  99/100'
+    assert out == ''
     bar.update(done=100)
     out, err = capsys.readouterr()
     assert out == '\rBar: ===================================== 100/100\n'


### PR DESCRIPTION
`bar(throttle=10)` => will render the bar only once every 10 iterations
`bar(throttle=0.01, total=3153214)` => will render the bar only once every 31532 iterations
`bar(throttle=timedelta(seconds=2))` => will render the bar only once every 2 seconds
