### PR TITLE
Add callback to use with urllib.request.urlretrieve

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,13 @@ Or the target total may change during process?
 
     bar.update(total=newcomputedtotal)
 
+To use as [urlretrieve](https://docs.python.org/3/library/urllib.request.html#urllib.request.urlretrieve)
+callback:
+
+    bar = ProgressBar(template="Download |{animation}| {done:B}/{total:B}")
+    urllib.request.urlretrieve(myurl, mydest, reporthook=bar.on_urlretrieve)
+
+
 See [examples](https://github.com/pyrates/progressist/blob/master/examples.py) for inspiration.
 
 To run examples, when git cloned the repository, simply run:

--- a/progressist/__init__.py
+++ b/progressist/__init__.py
@@ -201,6 +201,16 @@ class ProgressBar:
             # Spinner without total.
             self.finish()
 
+    def on_urlretrieve(self, blocknum, bs, size):
+        """Callback to use with urllib.request.urlretrieve"""
+        done = blocknum * bs
+        total = size if size > -1 else 0
+        if total:
+            # We don't have the real amount of bytes read, but the theorical
+            # amount, so on the last chunk the real amount may be smaller.
+            done = min(done, total)
+        self.update(done=done, total=total)
+
 
 # Manage sane default formats while keeping the original type to allow any
 # built-in formatting syntax.

--- a/progressist/tests/test_progress.py
+++ b/progressist/tests/test_progress.py
@@ -398,3 +398,12 @@ def test_next(bar, capsys):
     next(bar)
     out, err = capsys.readouterr()
     assert out == '\rBar: ==============                         38/100'
+
+
+def test_on_urlretrieve(bar, capsys, monkeypatch):
+    bar.on_urlretrieve(8, 8192, 70486)
+    out, err = capsys.readouterr()
+    assert out == "\rBar: ==============================    65536/70486"
+    bar.on_urlretrieve(9, 8192, 70486)
+    out, err = capsys.readouterr()
+    assert out == "\rBar: ================================= 70486/70486\n"


### PR DESCRIPTION
```
urllib.request.urlretrieve(myurl, mydest, reporthook=bar.on_urlretrieve)
```

~~Another option would be to specifically look for urlretrieve params in `bar.update`, and so one would do, without needing an extra method:~~ Not possible, as `reporthook` is called with args only.
